### PR TITLE
Have storage client inherit from minio client

### DIFF
--- a/storage.py
+++ b/storage.py
@@ -65,7 +65,7 @@ class StorageClient(Minio):
     def __exit__(self, exception_type, exception_value, traceback):
         self.close()
 
-    def get_or_create_bucket(self, bucket):
+    def get_or_make_bucket(self, bucket):
         try:
             self.make_bucket(bucket)
         except (

--- a/storage.py
+++ b/storage.py
@@ -296,3 +296,16 @@ class StorageClient(Minio):
             if len(errors):
                 error_msg = '\n\n'.join(map(str, errors))
                 raise error.MinioError(error_msg)
+
+    def remove_bucket(self, bucket_name, remove_objects=False):
+        """ Remove a bucket.
+
+        Args:
+            bucket_name (str): Name of the bucket.
+            remove_objects (bool): If True then remove all objects in the
+                bucket first.
+        """
+        if remove_objects:
+            list_objects = self.list_objects_v2(bucket_name, recursive=True)
+            self.remove_storage_objects(list_objects)
+        super().remove_bucket(bucket_name)

--- a/storage.py
+++ b/storage.py
@@ -23,13 +23,13 @@ class StorageObject:
         self,
         bucket,
         key,
-        value,
+        data,
         metadata=None,
     ):
         self.__dict__ = {
             'bucket': bucket,
             'key': key,
-            'value': value,
+            'data': data,
             'metadata': metadata or {}
         }
 
@@ -96,33 +96,33 @@ class StorageClient(Minio):
         return json.loads(s)
 
     @staticmethod
-    def helper_serialize_value(value, encoding='utf-8'):
-        if isinstance(value, bytes):
+    def helper_serialize_data(data, encoding='utf-8'):
+        if isinstance(data, bytes):
             serializer_method = None
             encoding = None
             content_type = 'application/octet-stream'
-            value_serialized = value
+            data_serialized = data
 
-        elif isinstance(value, str):
+        elif isinstance(data, str):
             serializer_method = 'str'
             encoding = encoding
             content_type = 'application/octet-stream'
-            value_serialized = value.encode(encoding)
+            data_serialized = data.encode(encoding)
 
-        elif isinstance(value, dict):
+        elif isinstance(data, dict):
             serializer_method = 'json'
             encoding = encoding
             content_type = f'application/json; charset={encoding}'
-            value_serialized = json.dumps(value).encode(encoding)
+            data_serialized = json.dumps(data).encode(encoding)
 
         else:
             raise TypeError(
-                f'No method for converting type {type(value)} to bytes'
+                f'No method for converting type {type(data)} to bytes'
             )
 
         return {
-            'value': value_serialized,
-            'value_length': len(value_serialized),
+            'data': data_serialized,
+            'data_length': len(data_serialized),
             'content_type': content_type,
             'serializer_info': {
                 'method': serializer_method,
@@ -131,46 +131,46 @@ class StorageClient(Minio):
         }
 
     @staticmethod
-    def helper_deserialize_value(value, serializer_info=None):
+    def helper_deserialize_data(data, serializer_info=None):
         if serializer_info is None:
-            return value
+            return data
 
         serializer_method = serializer_info['method']
         encoding = serializer_info['encoding']
         if serializer_method is None:
-            return value
+            return data
 
         elif serializer_method == 'str':
-            return value.decode(encoding)
+            return data.decode(encoding)
 
         elif serializer_method == 'json':
-            return json.loads(value.decode(encoding))
+            return json.loads(data.decode(encoding))
 
         else:
             raise error.MinioError(f'Unknown serializer method {serializer_method}')  # noqa
 
-    def create_storage_object(self, bucket, key, value=None, metadata=None, **kws):  # noqa
+    def create_storage_object(self, bucket, key, data=None, metadata=None, **kws):  # noqa
         return self.StorageObjectClass(
             bucket=bucket,
             key=key,
-            value=value,
+            data=data,
             metadata=metadata,
             **kws
         )
 
-    def put_value(self, bucket, key, value, metadata=None, encoding='utf-8'):
+    def put_data(self, bucket, key, data, metadata=None, encoding='utf-8'):
         """Put the content into storage.
 
         Args:
             bucket (str): Bucket category for the data.
             key (str): Key to store data at.
-            value (bytes | str | dict): Storage objects. Has multiple options.
+            data (bytes | str | dict): Storage objects. Has multiple options.
                 If other than bytes are provided then metadata will be updated.
 
                 * bytes: store these bytes exactly
                 * str: will use the "encoding" parameter to encode.
                     metadata['encoding'] = encoding
-                * dict: will use json.dumps(value).encode('utf-8')
+                * dict: will use json.dumps(data).encode('utf-8')
                     metadata.setdefault(
                         'content_type', 'application/json; charset=utf-8')
             metadata (dict): Information store about the data.
@@ -183,18 +183,18 @@ class StorageClient(Minio):
         storage_object = self.create_storage_object(
             bucket=bucket,
             key=key,
-            value=value,
+            data=data,
             metadata=metadata,
         )
 
-        serialized = self.helper_serialize_value(value, encoding=encoding)
+        serialized = self.helper_serialize_data(data, encoding=encoding)
 
         super().put_object(
             bucket_name=bucket,
             object_name=key,
-            data=io.BytesIO(serialized['value']),
+            data=io.BytesIO(serialized['data']),
             content_type=serialized['content_type'],
-            length=serialized['value_length'],
+            length=serialized['data_length'],
             metadata={
                 # these are headers which minio transforms metadata into
                 'X-Amz-Meta-SerializerInfo': self.serialize_metadata(serialized['serializer_info']),  # noqa
@@ -206,21 +206,21 @@ class StorageClient(Minio):
     def put_object(self, storage_object, encoding='utf-8'):
         """Put object into storage.
 
-        Also see: help(put_value)
+        Also see: help(put_data)
 
         Args:
             storage_object (StorageObject): The object containing the bucket
-                key, value, and metadata.
+                key, data, and metadata.
             encoding (str): Used for encoding if str is provided.
 
         Returns:
             StorageObject: new storage object from the components including the
                 storage client.
         """
-        self.put_value(
+        self.put_data(
             bucket=storage_object.bucket,
             key=storage_object.key,
-            value=storage_object.value,
+            data=storage_object.data,
             metadata=storage_object.metadata,
             encoding=encoding,
         )
@@ -231,7 +231,7 @@ class StorageClient(Minio):
         Args:
             bucket (str): Bucket category for the data.
             key (str): Key to store data at.
-            deserialize (bool): If True then will attempt to deserialize value.
+            deserialize (bool): If True then will attempt to deserialize data.
 
         Returns:
             StorageObject: The object sent to storage.
@@ -242,7 +242,7 @@ class StorageClient(Minio):
             object_name=key,
         )
 
-        value = self.helper_deserialize_value(
+        data = self.helper_deserialize_data(
             response.read(),
             serializer_info=self.deserialize_metadata(
                 response.getheader('X-Amz-Meta-SerializerInfo')
@@ -255,7 +255,7 @@ class StorageClient(Minio):
         return StorageObject(
             bucket=bucket,
             key=key,
-            value=value,
+            data=data,
             metadata=metadata,
         )
 

--- a/storage.py
+++ b/storage.py
@@ -203,7 +203,7 @@ class StorageClient(Minio):
         )
         return storage_object
 
-    def put_object(self, storage_object, encoding='utf-8'):
+    def put_storage_object(self, storage_object, encoding='utf-8'):
         """Put object into storage.
 
         Also see: help(put_data)
@@ -225,7 +225,7 @@ class StorageClient(Minio):
             encoding=encoding,
         )
 
-    def get_object(self, bucket_name, object_name, deserialize=True):
+    def get_storage_object(self, bucket_name, object_name, deserialize=True):
         """Get object and metadata from storage
 
         Args:
@@ -259,7 +259,7 @@ class StorageClient(Minio):
             metadata=metadata,
         )
 
-    def remove_object(self, storage_object):
+    def remove_storage_object(self, storage_object):
         """ Remove object from bucket.
 
         Args:
@@ -271,7 +271,7 @@ class StorageClient(Minio):
             object_name=storage_object.object_name,
         )
 
-    def remove_objects(self, storage_objects):
+    def remove_storage_objects(self, storage_objects):
         """ Remove objects from bucket.
 
         Objects are deleted in batch. 

--- a/test_storage.py
+++ b/test_storage.py
@@ -37,10 +37,10 @@ class TestStorageClient(unittest.TestCase):
     def test_storage_client(self):
         client = self.client
 
-        obj_put = client.put_value(
+        obj_put = client.put_data(
             bucket=self.bucket,
             key='turtle/rabbit.json',
-            value={"hello": "world\u0000"},
+            data={"hello": "world\u0000"},
             metadata={'meta': 'data'},
         )
 
@@ -59,14 +59,14 @@ class TestStorageClient(unittest.TestCase):
         )
         self.assertEqual(answer, correct_answer)
 
-    def test_storage_client_serialize_value(self):
+    def test_storage_client_serialize_data(self):
         client = self.client
 
-        value = b'abc'
-        answer = client.helper_serialize_value(value)
+        data = b'abc'
+        answer = client.helper_serialize_data(data)
         correct_answer = {
-            'value': b'abc',
-            'value_length': 3,
+            'data': b'abc',
+            'data_length': 3,
             'content_type': 'application/octet-stream',
             'serializer_info': {
                 'method': None,
@@ -75,11 +75,11 @@ class TestStorageClient(unittest.TestCase):
         }
         self.assertEqual(answer, correct_answer)
 
-        value = 'abc'
-        answer = client.helper_serialize_value(value)
+        data = 'abc'
+        answer = client.helper_serialize_data(data)
         correct_answer = {
-            'value': b'abc',
-            'value_length': 3,
+            'data': b'abc',
+            'data_length': 3,
             'content_type': 'application/octet-stream',
             'serializer_info': {
                 'method': 'str',
@@ -88,11 +88,11 @@ class TestStorageClient(unittest.TestCase):
         }
         self.assertEqual(answer, correct_answer)
 
-        value = 'abc'
-        answer = client.helper_serialize_value(value, encoding='ascii')
+        data = 'abc'
+        answer = client.helper_serialize_data(data, encoding='ascii')
         correct_answer = {
-            'value': b'abc',
-            'value_length': 3,
+            'data': b'abc',
+            'data_length': 3,
             'content_type': 'application/octet-stream',
             'serializer_info': {
                 'method': 'str',
@@ -101,11 +101,11 @@ class TestStorageClient(unittest.TestCase):
         }
         self.assertEqual(answer, correct_answer)
 
-        value = {'hello': 'world'}
-        answer = client.helper_serialize_value(value)
+        data = {'hello': 'world'}
+        answer = client.helper_serialize_data(data)
         correct_answer = {
-            'value': b'{"hello": "world"}',
-            'value_length': 18,
+            'data': b'{"hello": "world"}',
+            'data_length': 18,
             'content_type': 'application/json; charset=utf-8',
             'serializer_info': {
                 'method': 'json',
@@ -114,11 +114,11 @@ class TestStorageClient(unittest.TestCase):
         }
         self.assertEqual(answer, correct_answer)
 
-        value = {'hello': 'world'}
-        answer = client.helper_serialize_value(value, encoding='ascii')
+        data = {'hello': 'world'}
+        answer = client.helper_serialize_data(data, encoding='ascii')
         correct_answer = {
-            'value': b'{"hello": "world"}',
-            'value_length': 18,
+            'data': b'{"hello": "world"}',
+            'data_length': 18,
             'content_type': 'application/json; charset=ascii',
             'serializer_info': {
                 'method': 'json',
@@ -130,10 +130,10 @@ class TestStorageClient(unittest.TestCase):
     def test_storage_client_remove_object(self):
         client = self.client
 
-        obj = client.put_value(
+        obj = client.put_data(
             bucket=self.bucket,
             key=f'rabbit_deleteme.json',
-            value={"hello": "world"},
+            data={"hello": "world"},
         )
 
         client.remove_object(obj)
@@ -153,10 +153,10 @@ class TestStorageClient(unittest.TestCase):
         objects = []
         for i in range(3):
             objects.append(
-                client.put_value(
+                client.put_data(
                     bucket=bucket,
                     key=f'turtle/rabbit{i}.json',
-                    value={"hello": i},
+                    data={"hello": i},
                 )
             )
         client.remove_objects(objects)

--- a/test_storage.py
+++ b/test_storage.py
@@ -39,14 +39,14 @@ class TestStorageClient(unittest.TestCase):
 
         obj_put = client.put_data(
             bucket=self.bucket,
-            key='turtle/rabbit.json',
+            object_name='turtle/rabbit.json',
             data={"hello": "world\u0000"},
             metadata={'meta': 'data'},
         )
 
         obj_get = client.get_object(
             bucket=obj_put.bucket,
-            key=obj_put.key,
+            object_name=obj_put.object_name,
         )
 
         self.assertEqual(obj_put, obj_get)
@@ -132,7 +132,7 @@ class TestStorageClient(unittest.TestCase):
 
         obj = client.put_data(
             bucket=self.bucket,
-            key=f'rabbit_deleteme.json',
+            object_name=f'rabbit_deleteme.json',
             data={"hello": "world"},
         )
 
@@ -143,7 +143,7 @@ class TestStorageClient(unittest.TestCase):
             client.get_object,
             # **kws
             bucket=obj.bucket,
-            key=obj.key,
+            object_name=obj.object_name,
         )
 
     def test_storage_client_remove_objects(self):
@@ -155,7 +155,7 @@ class TestStorageClient(unittest.TestCase):
             objects.append(
                 client.put_data(
                     bucket=bucket,
-                    key=f'turtle/rabbit{i}.json',
+                    object_name=f'turtle/rabbit{i}.json',
                     data={"hello": i},
                 )
             )
@@ -167,7 +167,7 @@ class TestStorageClient(unittest.TestCase):
                 client.get_object,
                 # **kws
                 bucket=obj.bucket,
-                key=obj.key,
+                object_name=obj.object_name,
             )
 
     def test_remove_bucket(self):

--- a/test_storage.py
+++ b/test_storage.py
@@ -32,7 +32,7 @@ class TestStorageClient(unittest.TestCase):
 
     def setUp(self):
         self.bucket = 'rabbit'
-        self.client.get_or_create_bucket(self.bucket)
+        self.client.get_or_make_bucket(self.bucket)
 
     def test_storage_client(self):
         client = self.client
@@ -169,6 +169,9 @@ class TestStorageClient(unittest.TestCase):
                 bucket=obj.bucket,
                 key=obj.key,
             )
+
+    def test_remove_bucket(self):
+        pass
 
 
 if __name__ == '__main__':

--- a/test_storage.py
+++ b/test_storage.py
@@ -44,7 +44,25 @@ class TestStorageClient(unittest.TestCase):
             metadata={'meta': 'data'},
         )
 
-        obj_get = client.get_object(
+        obj_get = client.get_storage_object(
+            bucket_name=obj_put.bucket_name,
+            object_name=obj_put.object_name,
+        )
+
+        self.assertEqual(obj_put, obj_get)
+
+    def test_put_storage_object(self):
+        client = self.client
+
+        obj_put = client.create_storage_object(
+            bucket_name=self.bucket_name,
+            object_name='turtle/rabbit.json',
+            data={"hello": "world\u0000"},
+            metadata={'meta': 'data'},
+        )
+        client.put_storage_object(obj_put)
+
+        obj_get = client.get_storage_object(
             bucket_name=obj_put.bucket_name,
             object_name=obj_put.object_name,
         )
@@ -136,7 +154,7 @@ class TestStorageClient(unittest.TestCase):
             data={"hello": "world"},
         )
 
-        client.remove_object(obj)
+        client.remove_storage_object(obj)
 
         self.assertRaises(
             storage.error.NoSuchKey,
@@ -159,7 +177,7 @@ class TestStorageClient(unittest.TestCase):
                     data={"hello": i},
                 )
             )
-        client.remove_objects(objects)
+        client.remove_storage_objects(objects)
 
         for obj in objects:
             self.assertRaises(

--- a/test_storage.py
+++ b/test_storage.py
@@ -25,20 +25,23 @@ def create_client():
 
 
 class TestStorageClient(unittest.TestCase):
+    testing_bucket = 'unittests'
 
     @classmethod
     def setUpClass(cls):
         cls.client = create_client()
 
     def setUp(self):
-        self.bucket_name = 'rabbit'
-        self.client.get_or_make_bucket(self.bucket_name)
+        self.client.get_or_make_bucket(self.testing_bucket)
+
+    def tearDown(self):
+        self.client.remove_bucket(self.testing_bucket, remove_objects=True)
 
     def test_storage_client(self):
         client = self.client
 
         obj_put = client.put_data(
-            bucket_name=self.bucket_name,
+            bucket_name=self.testing_bucket,
             object_name='turtle/rabbit.json',
             data={"hello": "world\u0000"},
             metadata={'meta': 'data'},
@@ -55,7 +58,7 @@ class TestStorageClient(unittest.TestCase):
         client = self.client
 
         obj_put = client.create_storage_object(
-            bucket_name=self.bucket_name,
+            bucket_name=self.testing_bucket,
             object_name='turtle/rabbit.json',
             data={"hello": "world\u0000"},
             metadata={'meta': 'data'},
@@ -149,7 +152,7 @@ class TestStorageClient(unittest.TestCase):
         client = self.client
 
         obj = client.put_data(
-            bucket_name=self.bucket_name,
+            bucket_name=self.testing_bucket,
             object_name=f'rabbit_deleteme.json',
             data={"hello": "world"},
         )
@@ -166,7 +169,7 @@ class TestStorageClient(unittest.TestCase):
 
     def test_storage_client_remove_objects(self):
         client = self.client
-        bucket_name = self.bucket_name
+        bucket_name = self.testing_bucket
 
         objects = []
         for i in range(3):
@@ -187,9 +190,6 @@ class TestStorageClient(unittest.TestCase):
                 bucket_name=obj.bucket_name,
                 object_name=obj.object_name,
             )
-
-    def test_remove_bucket(self):
-        pass
 
 
 if __name__ == '__main__':

--- a/test_storage.py
+++ b/test_storage.py
@@ -31,21 +31,21 @@ class TestStorageClient(unittest.TestCase):
         cls.client = create_client()
 
     def setUp(self):
-        self.bucket = 'rabbit'
-        self.client.get_or_make_bucket(self.bucket)
+        self.bucket_name = 'rabbit'
+        self.client.get_or_make_bucket(self.bucket_name)
 
     def test_storage_client(self):
         client = self.client
 
         obj_put = client.put_data(
-            bucket=self.bucket,
+            bucket_name=self.bucket_name,
             object_name='turtle/rabbit.json',
             data={"hello": "world\u0000"},
             metadata={'meta': 'data'},
         )
 
         obj_get = client.get_object(
-            bucket=obj_put.bucket,
+            bucket_name=obj_put.bucket_name,
             object_name=obj_put.object_name,
         )
 
@@ -131,7 +131,7 @@ class TestStorageClient(unittest.TestCase):
         client = self.client
 
         obj = client.put_data(
-            bucket=self.bucket,
+            bucket_name=self.bucket_name,
             object_name=f'rabbit_deleteme.json',
             data={"hello": "world"},
         )
@@ -142,19 +142,19 @@ class TestStorageClient(unittest.TestCase):
             storage.error.NoSuchKey,
             client.get_object,
             # **kws
-            bucket=obj.bucket,
+            bucket_name=obj.bucket_name,
             object_name=obj.object_name,
         )
 
     def test_storage_client_remove_objects(self):
         client = self.client
-        bucket = self.bucket
+        bucket_name = self.bucket_name
 
         objects = []
         for i in range(3):
             objects.append(
                 client.put_data(
-                    bucket=bucket,
+                    bucket_name=bucket_name,
                     object_name=f'turtle/rabbit{i}.json',
                     data={"hello": i},
                 )
@@ -166,7 +166,7 @@ class TestStorageClient(unittest.TestCase):
                 storage.error.NoSuchKey,
                 client.get_object,
                 # **kws
-                bucket=obj.bucket,
+                bucket_name=obj.bucket_name,
                 object_name=obj.object_name,
             )
 


### PR DESCRIPTION
# What

Have the storage client inherit from the minio client and more closely follow their API standards.

# Why

There are methods I wanted to access when using the client downstream that I couldn't so it makes sense to expose more of those by just inheriting from Minio. Since I will be inheriting from Minio I might as well update the interface to better match their API for consistency.

# Testing

All changes are covered via unittests so run `python test_storage.py`